### PR TITLE
Feat: logo routes to home

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -9,7 +9,10 @@ h1{
   padding: 10px 50px;
   text-align: center;
   height: 100%;
+  cursor: pointer;
 }
+
+/* .logo-container  */
 
 header{
   display: flex;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <header>
-  <div class="logo-container">
+  <div class="logo-container" (click)="returnToHome()">
     <h1 class="header">Note</h1>
     <h1 class="header">Taker</h1>
   </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
+
 
 @Component({
   standalone: true,
@@ -9,4 +10,11 @@ import { RouterModule } from '@angular/router';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent { }
+export class AppComponent { 
+
+constructor(private router: Router) {}
+
+  returnToHome(): void {
+    this.router.navigate(['/'])
+  }
+}


### PR DESCRIPTION
## Type of Change
- [x] feature ⛲


## Description
Added routing to the logo in the header, clicking returns to the homescreen.

## Motivation and Context
Wanted to add a standardized user experience. An end user would expect clicking the logo to return to home screen.

## Related Tickets
Related to ticket 25, need to add cypress testing.

## Screenshots (if appropriate): 
N/A

## Added Test?

- [x No 🙅
- [x] All previous tests still pass 🥳



## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
